### PR TITLE
Remove display on portal dictionary and documentation XMLs

### DIFF
--- a/73f7721583222210621299e0deaad380/update/sys_dictionary_x_1086142_promptce_prompt_display_on_portal.xml
+++ b/73f7721583222210621299e0deaad380/update/sys_dictionary_x_1086142_promptce_prompt_display_on_portal.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- file content will be uploaded as-is from the local file -->

--- a/73f7721583222210621299e0deaad380/update/sys_documentation_x_1086142_promptce_prompt_display_on_portal_en.xml
+++ b/73f7721583222210621299e0deaad380/update/sys_documentation_x_1086142_promptce_prompt_display_on_portal_en.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- file content will be uploaded as-is from the local file -->


### PR DESCRIPTION
This PR removes the following files by making them empty:
- 73f7721583222210621299e0deaad380/update/sys_dictionary_x_1086142_promptce_prompt_display_on_portal.xml
- 73f7721583222210621299e0deaad380/update/sys_documentation_x_1086142_promptce_prompt_display_on_portal_en.xml

These files are now empty to reflect their removal from the project.