### PR TITLE
Add 'Display on Portal' boolean field and documentation

### DIFF
--- a/73f7721583222210621299e0deaad380/update/sys_dictionary_x_1086142_promptce_prompt_display_on_portal.xml
+++ b/73f7721583222210621299e0deaad380/update/sys_dictionary_x_1086142_promptce_prompt_display_on_portal.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="display_on_portal" table="x_1086142_promptce_prompt">
+        <active>true</active>
+        <array>false</array>
+        <attributes/>
+        <audit>false</audit>
+        <calculation/>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label>Display on Portal</column_label>
+        <comments/>
+        <create_roles/>
+        <default_value>true</default_value>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>display_on_portal</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="True/False">boolean</internal_type>
+        <mandatory>false</mandatory>
+        <max_length/>
+        <name>x_1086142_promptce_prompt</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2025-07-04 14:15:13</sys_created_on>
+        <sys_name>Display on Portal</sys_name>
+        <sys_package display_value="Promptception" source="x_1086142_promptce">73f7721583222210621299e0deaad380</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="Promptception">73f7721583222210621299e0deaad380</sys_scope>
+        <sys_update_name>sys_dictionary_x_1086142_promptce_prompt_display_on_portal</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2025-07-04 14:15:13</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type/>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/73f7721583222210621299e0deaad380/update/sys_documentation_x_1086142_promptce_prompt_display_on_portal_en.xml
+++ b/73f7721583222210621299e0deaad380/update/sys_documentation_x_1086142_promptce_prompt_display_on_portal_en.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="display_on_portal" label="Display on Portal" language="en" table="x_1086142_promptce_prompt">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element>display_on_portal</element>
+            <help>This field determines whether the prompt is visible on the portal. Set to true to display the prompt on the portal, or false to hide it. By default, this is set to true.</help>
+            <hint/>
+            <label>Display on Portal</label>
+            <language>en</language>
+            <name>x_1086142_promptce_prompt</name>
+            <plural>Display on Portals</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>admin</sys_created_by>
+            <sys_created_on>2025-07-04 14:15:13</sys_created_on>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>Display on Portal</sys_name>
+            <sys_package display_value="Promptception" source="x_1086142_promptce">73f7721583222210621299e0deaad380</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="Promptception">73f7721583222210621299e0deaad380</sys_scope>
+            <sys_update_name>sys_documentation_x_1086142_promptce_prompt_display_on_portal_en</sys_update_name>
+            <sys_updated_by>admin</sys_updated_by>
+            <sys_updated_on>2025-07-04 14:15:13</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>


### PR DESCRIPTION
This pull request adds a new boolean field 'Display on Portal' (default: true) to the x_1086142_promptce_prompt table, along with a corresponding documentation entry. These changes allow prompts to be selectively displayed on the portal.